### PR TITLE
Use a standard flat style for settings.

### DIFF
--- a/ptree/project_template/manage.py
+++ b/ptree/project_template/manage.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
-import os, sys
-import django.conf
-import {{ project_name }}.settings
+import os
+import sys
 
 if __name__ == "__main__":
-    if not django.conf.settings.configured:
-        django.conf.settings.configure(**{{ project_name }}.settings.settings)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings")
+
     from django.core.management import execute_from_command_line
+
     execute_from_command_line(sys.argv)

--- a/ptree/project_template/project_name/settings.py
+++ b/ptree/project_template/project_name/settings.py
@@ -1,9 +1,9 @@
 import os
-import ptree.settings
+from ptree.settings import *
 
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-
+# You'll want to override these in production.
 DEBUG = True
+TEMPLATE_DEBUG = True
 
 DATABASES = {
     'default': {
@@ -12,25 +12,32 @@ DATABASES = {
     }
 }
 
-settings = {
-    'CREATE_DEFAULT_SUPERUSER': True,
-    'ADMIN_USERNAME': 'ptree',
-    'ADMIN_PASSWORD': 'ptree',
-    'AWS_ACCESS_KEY_ID': os.environ.get('AWS_ACCESS_KEY_ID'),
-    'AWS_SECRET_ACCESS_KEY': os.environ.get('AWS_SECRET_ACCESS_KEY'),
-    'DEBUG': DEBUG,
-    'DATABASES': DATABASES,
-    'INSTALLED_APPS': [
-        'ptree',
-    ],
-    'INSTALLED_PTREE_APPS': [
-    ],
-    # don't share this with anybody.
-    # Change this to something unique (e.g. mash your keyboard), and then delete this comment.
-    'SECRET_KEY': 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz',
-    'BASE_DIR': BASE_DIR,
-    'WSGI_APPLICATION': '{{ project_name }}.wsgi.application',
-    'ROOT_URLCONF': '{{ project_name }}.urls',
-}
+# You shouldn't need to change these.
+WSGI_APPLICATION = '{{ project_name }}.wsgi.application'
+ROOT_URLCONF = '{{ project_name }}.urls'
 
-ptree.settings.augment_settings(settings)
+# Automatically create a superuser during syncdb.
+CREATE_DEFAULT_SUPERUSER = True
+ADMIN_USERNAME = 'ptree'
+ADMIN_PASSWORD = 'ptree'
+
+# Get AWS credentials from enviroment variables.
+AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')
+AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY')
+
+# Don't share this with anybody.
+# Change this to something unique (e.g. mash your keyboard), and then delete this comment.
+SECRET_KEY = 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'
+
+# This setting is required for ptree to determine which URLs
+# to automatically add to the project.
+INSTALLED_PTREE_APPS = []
+
+# Ensure we add in any ptree apps to Django's standard 'INSTALLED_APPS' setting.
+INSTALLED_APPS += INSTALLED_PTREE_APPS
+
+# If you need to install other third party apps or middleware,
+# it's best to append these to the existing set of defaults,
+# so that the default set of ptree requirements are left as-is.
+# INSTALLED_APPS += []
+# MIDDLEWARE_CLASSES += []

--- a/ptree/settings.py
+++ b/ptree/settings.py
@@ -1,99 +1,51 @@
-from django.conf import settings
-from collections import OrderedDict
 import os
-import django.conf
-import django.contrib.sessions.serializers
 
-def remove_duplicates(lst):
-    return list(OrderedDict.fromkeys(lst))
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
-def collapse_to_unique_list(*args):
-    combined_list = []
-    for arg in args:
-        if arg is not None:
-            combined_list += list(arg)
-    return remove_duplicates(combined_list)
+CRISPY_TEMPLATE_PACK = 'bootstrap3'
 
-def augment_settings(settings):
-
-
-
-    default_installed_apps = [
-        'django.contrib.contenttypes',
-        'django.contrib.sessions',
-        'django.contrib.messages',
-        'django.contrib.staticfiles',
-        'ptree.stuff',
-    ]
-
-    third_party_apps = ['data_exports', 'crispy_forms']
-
-    # order is important:
-    # ptree unregisters User & Group, which are installed by auth.
-    # ptree templates need to get loaded before the admin.
-    # but ptree also unregisters data_exports, which comes afterwards?
-    new_installed_apps = collapse_to_unique_list(['django.contrib.auth',
-                                                  'ptree',
-                                                  'django.contrib.admin',],
-                                                 default_installed_apps,
-                                                 third_party_apps,
-                                                 settings['INSTALLED_APPS'],
-                                                 settings['INSTALLED_PTREE_APPS'])
-
-    new_template_dirs = collapse_to_unique_list(
-        [os.path.join(settings['BASE_DIR'], 'templates/')],
-         settings.get('TEMPLATE_DIRS'))
-
-    new_staticfiles_dirs = collapse_to_unique_list(settings.get('STATICFILES_DIRS'),
-        [os.path.join(settings['BASE_DIR'], 'static')])
-
-    new_middleware_classes = collapse_to_unique_list(
-        ['django.middleware.common.CommonMiddleware',
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',],
-        settings.get('MIDDLEWARE_CLASSES')
-    )
-
-    augmented_settings = {
-        'INSTALLED_APPS': new_installed_apps,
-        'TEMPLATE_DIRS': new_template_dirs,
-        'STATICFILES_DIRS': new_staticfiles_dirs,
-        'MIDDLEWARE_CLASSES': new_middleware_classes,
-    }
+# pages with a time limit for the participant can have a grace period
+# to compensate for network latency.
+# the timer is started and stopped server-side,
+# so this grace period should account for time spent during
+# download, upload, page rendering, etc.
+TIME_LIMIT_GRACE_PERIOD_SECONDS = 5
+SESSION_SAVE_EVERY_REQUEST = True
+STATIC_ROOT = 'staticfiles'
+STATIC_URL = '/static/'
+CURRENCY_CODE = 'USD'
+CURRENCY_LOCALE = 'en_US'
+CURRENCY_DECIMAL_PLACES = 2
+TIME_ZONE = 'UTC'
+SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
+ALLOWED_HOSTS = ['*']
 
 
+TEMPLATE_DIRS = [
+    os.path.join(BASE_DIR, 'templates')
+]
 
-    overridable_settings = {
-        'CRISPY_TEMPLATE_PACK': 'bootstrap3',
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, 'static')
+]
 
-        # pages with a time limit for the participant can have a grace period
-        # to compensate for network latency.
-        # the timer is started and stopped server-side,
-        # so this grace period should account for time spent during
-        # download, upload, page rendering, etc.
-        'TIME_LIMIT_GRACE_PERIOD_SECONDS': 5,
-        'SESSION_SAVE_EVERY_REQUEST': True,
-        'TEMPLATE_DEBUG': settings['DEBUG'],
-        'STATIC_ROOT': 'staticfiles',
-        'STATIC_URL': '/static/',
-        'CURRENCY_CODE': 'USD',
-        'CURRENCY_LOCALE': 'en_US',
-        'CURRENCY_DECIMAL_PLACES': 2,
-        'TIME_ZONE': 'UTC',
-        'SESSION_SERIALIZER': 'django.contrib.sessions.serializers.PickleSerializer',
-        'ALLOWED_HOSTS': ['*'],
-    }
+MIDDLEWARE_CLASSES = [
+    'django.middleware.common.CommonMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware'
+]
 
-
-    settings.update(augmented_settings)
-
-    for k,v in overridable_settings.items():
-        if not settings.has_key(k):
-            settings[k] = v
-
-
-
-
-
+INSTALLED_APPS = [
+    'django.contrib.auth',
+    'ptree',
+    'django.contrib.admin',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'ptree.stuff',
+    'data_exports',
+    'crispy_forms'
+]


### PR DESCRIPTION
This style still allows you to modify ptree's defaults, and upgrade
ptree to add in additional installed apps and middleware.
