### PR TITLE
Use heroku requirements file in travis builds in order to get the psycop...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   # Setup integration tests.
   - git clone https://github.com/oTree-org/oTree.git otree-lib
   - virtualenv otree-lib/.env --no-site-packages
-  - otree-lib/.env/bin/pip install -r otree-lib/requirements_base.txt
+  - otree-lib/.env/bin/pip install -r otree-lib/requirements_heroku.txt
   - otree-lib/.env/bin/python setup.py install
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres


### PR DESCRIPTION
...g2 module installed.