### PR TITLE
Add template syntax check

### DIFF
--- a/otree/checks/__init__.py
+++ b/otree/checks/__init__.py
@@ -132,7 +132,7 @@ class Rules(object):
         try:
             with open(template_name, 'r') as f:
                 compiled_template = Template(f.read())
-        except (IOError, OSError):
+        except (IOError, OSError, TemplateSyntaxError):
             # Ignore errors that occured during file-read or compilation.
             return
 


### PR DESCRIPTION
This adds a check that tests all templates in user defined apps for valid syntax. It displays a nice error message with a snippet showing parts of the file in question.

Example:
![screen1](https://cloud.githubusercontent.com/assets/88278/9928116/164be078-5d24-11e5-8bb4-fc15c7f78f3a.png)
