### PR TITLE
fix to include styles in non-debug/mod_wsgi

### DIFF
--- a/otree/templates/otree/includes/InternalStyles.html
+++ b/otree/templates/otree/includes/InternalStyles.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <!-- compiled and minified CSS -->


### PR DESCRIPTION
We realized styles were not working in non-debug with apache2/mod_wsgi. However, they were working in past versions of otree (0.3.x), in debug mode, and also with runserver (w/o debug). Any hint why this is actually the case is appreciated, since it will make it more easy to find something like this next time.

Paul