### PR TITLE
Reliably save changes of models in views to the database

### DIFF
--- a/otree/models/participant.py
+++ b/otree/models/participant.py
@@ -8,7 +8,8 @@ from otree.common_internal import id_label_name
 from otree.common import Currency as c
 from otree.db import models
 from otree.models_concrete import ParticipantToPlayerLookup
-from otree.models.session import Session, ModelWithVars
+from otree.models.session import Session
+from otree.models.varsmixin import ModelWithVars
 
 
 class Participant(ModelWithVars):

--- a/otree/models/session.py
+++ b/otree/models/session.py
@@ -1,10 +1,9 @@
-import copy
 import django.test
 
 from otree import constants_internal
 import otree.common_internal
 from otree.db import models
-from otree_save_the_change.mixins import SaveTheChange
+from .varsmixin import ModelWithVars
 
 
 class GlobalSingleton(models.Model):
@@ -20,23 +19,6 @@ class GlobalSingleton(models.Model):
         length=8, doc=('used for authentication to things only the '
                        'admin/experimenter should access')
     )
-
-
-class ModelWithVars(SaveTheChange, models.Model):
-    vars = models.JSONField(default=dict)
-
-    class Meta:
-        abstract = True
-
-    def __init__(self, *args, **kwargs):
-        super(ModelWithVars, self).__init__(*args, **kwargs)
-        self._old_vars = copy.deepcopy(self.vars)
-
-    def save(self, *args, **kwargs):
-        # Trick otree_save_the_change to update vars
-        if hasattr(self, '_changed_fields') and self.vars != self._old_vars:
-            self._changed_fields['vars'] = self._old_vars
-        super(ModelWithVars, self).save(*args, **kwargs)
 
 
 # for now removing SaveTheChange

--- a/otree/models/varsmixin.py
+++ b/otree/models/varsmixin.py
@@ -1,0 +1,24 @@
+import copy
+from otree_save_the_change.mixins import SaveTheChange
+
+from otree.db import models
+
+
+class ModelWithVars(SaveTheChange, models.Model):
+    vars = models.JSONField(default=dict)
+
+    class Meta:
+        abstract = True
+
+    def __init__(self, *args, **kwargs):
+        super(ModelWithVars, self).__init__(*args, **kwargs)
+        self._old_vars = copy.deepcopy(self.vars)
+
+    def _vars_have_changed(self):
+        return self.vars != self._old_vars
+
+    def save(self, *args, **kwargs):
+        # Trick otree_save_the_change to update vars
+        if hasattr(self, '_changed_fields') and self._vars_have_changed():
+            self._changed_fields['vars'] = self._old_vars
+        super(ModelWithVars, self).save(*args, **kwargs)

--- a/otree/views/abstract.py
+++ b/otree/views/abstract.py
@@ -42,7 +42,7 @@ from otree.models_concrete import (
     PageTimeout, StubModel,
     ParticipantLockModel)
 from otree_save_the_change.mixins import SaveTheChange
-from otree.models.session import ModelWithVars
+from otree.models.varsmixin import ModelWithVars
 
 
 # Get an instance of a logger
@@ -101,7 +101,7 @@ class SaveObjectsMixin(object):
             # We need special support for the vars JSONField as SaveTheChange
             # does not detect the change.
             if isinstance(instance, ModelWithVars):
-                if instance._old_vars != instance.vars:
+                if instance._vars_have_changed():
                     return True
             return False
         # Save always if the model is not a SaveTheChange instance.

--- a/otree/views/abstract.py
+++ b/otree/views/abstract.py
@@ -42,6 +42,7 @@ from otree.models_concrete import (
     PageTimeout, StubModel,
     ParticipantLockModel)
 from otree_save_the_change.mixins import SaveTheChange
+from otree.models.session import ModelWithVars
 
 
 # Get an instance of a logger
@@ -95,10 +96,14 @@ class SaveObjectsMixin(object):
     def _save_objects_shall_save(self, instance):
         # If ``SaveTheChange`` has recoreded any changes, then save.
         if isinstance(instance, SaveTheChange):
-            if getattr(instance, '_changed_fields', None):
+            if instance._changed_fields:
                 return True
-            else:
-                return False
+            # We need special support for the vars JSONField as SaveTheChange
+            # does not detect the change.
+            if isinstance(instance, ModelWithVars):
+                if instance._old_vars != instance.vars:
+                    return True
+            return False
         # Save always if the model is not a SaveTheChange instance.
         return True
 

--- a/tests/test_views_saveobjectsmixin.py
+++ b/tests/test_views_saveobjectsmixin.py
@@ -1,0 +1,116 @@
+from datetime import datetime
+from django.core.management import call_command
+from mock import Mock
+import idmap.tls
+
+from .base import TestCase
+
+from otree.models import Participant
+from otree.models import Session
+from otree.views.abstract import SaveObjectsMixin
+
+
+class SaveObjectsMixinTest(TestCase):
+    def setUp(self):
+        # Mock required model classes from app.
+        self.mixin = SaveObjectsMixin()
+
+        class Dummy(object):
+            pass
+        self.mixin.PlayerClass = Dummy
+        self.mixin.GroupClass = Dummy
+        self.mixin.SubsessionClass = Dummy
+
+    def test_dont_save_if_no_change(self):
+        with self.assertNumQueries(0):
+            self.mixin.save_objects()
+
+        call_command('create_session', 'simple_game', '1')
+        # Reset cache.
+        idmap.tls.init_idmap()
+
+        participant = Participant.objects.get()
+
+        # We keep track of the participant.
+        instances = self.mixin._get_save_objects_model_instances()
+        self.assertEqual(instances, [participant])
+
+        # But we won't save the participant since we didn't change it.
+        with self.assertNumQueries(0):
+            self.mixin.save_objects()
+
+    def test_save_if_changed(self):
+        call_command('create_session', 'simple_game', '1')
+        # Reset cache.
+        idmap.tls.init_idmap()
+
+        participant = Participant.objects.get()
+        participant.save = Mock()
+
+        self.mixin.save_objects()
+        # No change, no save.
+        self.assertFalse(participant.save.called)
+
+        participant.time_started = datetime.utcnow()
+        self.mixin.save_objects()
+        # Has change, then save.
+        self.assertTrue(participant.save.called)
+
+    def test_nested_changes(self):
+        call_command('create_session', 'simple_game', '1')
+        # Reset cache.
+        idmap.tls.init_idmap()
+
+        # Query participant via session.
+        session = Session.objects.get()
+        participant = session.participant_set.get()
+        participant.is_on_wait_page = not participant.is_on_wait_page
+
+        # Save participant.
+        with self.assertNumQueries(1):
+            self.mixin.save_objects()
+
+    def test_with_app_models(self):
+        call_command('create_session', 'simple_game', '2')
+
+        from simple_game.models import Group
+        from simple_game.models import Player
+        from simple_game.models import Subsession
+
+        mixin = SaveObjectsMixin()
+        mixin.GroupClass = Group
+        mixin.PlayerClass = Player
+        mixin.SubsessionClass = Subsession
+
+        # Reset cache.
+        idmap.tls.init_idmap()
+
+        players = Player.objects.all()
+        self.assertEqual(len(players), 2)
+
+        group = players[0].group
+        group.save = Mock()
+        group.round_number += 1
+
+        # Query session object to test that it's loaded..
+        group.session
+        participants = group.session.participant_set.all()
+
+        all_instances = set((
+            players[0],
+            players[1],
+            group,
+            group.session,
+            participants[0],
+            participants[1]))
+
+        self.assertEqual(
+            set(mixin._get_save_objects_model_instances()),
+            all_instances)
+
+        # No queries are executed. The group model shall be saved, but we
+        # mocked out the save method. All other models should be left untouched.
+        with self.assertNumQueries(0):
+            mixin.save_objects()
+
+        self.assertTrue(group.save.called)

--- a/tests/test_views_saveobjectsmixin.py
+++ b/tests/test_views_saveobjectsmixin.py
@@ -109,7 +109,8 @@ class SaveObjectsMixinTest(TestCase):
             all_instances)
 
         # No queries are executed. The group model shall be saved, but we
-        # mocked out the save method. All other models should be left untouched.
+        # mocked out the save method. All other models should be left
+        # untouched.
         with self.assertNumQueries(0):
             mixin.save_objects()
 


### PR DESCRIPTION
We use the idmap cache for this and introcuced a new view mixin called ``SaveObjectsMixin``. It will iterate through the idmap model cache and save all those instances that were changed. The change detection is handled by ``otree_save_the_change.mixins.SaveTheChange``.

Fixes #407 

By default only the Player, Group, Subsession, Participant and Session models are monitored and saved at the end of the view.
