### PR TITLE
fixed problem with resetdb and mysql: "#1071 - Specified key was too …

### DIFF
--- a/otree/migrations/0001_initial.py
+++ b/otree/migrations/0001_initial.py
@@ -176,7 +176,7 @@ class Migration(migrations.Migration):
                 ('comment', otree.db.models.TextField(blank=True, null=True)),
                 ('_anonymous_code', otree.db.models.CharField(db_index=True, max_length=8, null=True, default=otree.common_internal.random_chars_10)),
                 ('special_category', otree.db.models.CharField(db_index=True, max_length=20, null=True)),
-                ('_pre_create_id', otree.db.models.CharField(db_index=True, max_length=300, null=True)),
+                ('_pre_create_id', otree.db.models.CharField(db_index=True, max_length=255, null=True)),
                 ('_use_browser_bots', otree.db.models.BooleanField(choices=[(True, 'Yes'), (False, 'No')], default=False)),
             ],
             options={

--- a/otree/models/session.py
+++ b/otree/models/session.py
@@ -93,7 +93,7 @@ class Session(ModelWithVars):
     _anonymous_code = models.CharField(
         default=random_chars_10, max_length=10, null=False, db_index=True)
 
-    _pre_create_id = models.CharField(max_length=300, db_index=True, null=True)
+    _pre_create_id = models.CharField(max_length=255, db_index=True, null=True)
 
     use_browser_bots = models.BooleanField(default=False)
 

--- a/otree/templates/otree/admin/Sessions.html
+++ b/otree/templates/otree/admin/Sessions.html
@@ -103,9 +103,15 @@ $(document).ready(function() {
 }
 </style>
 {% endblock %}
+
 {% block title %}
 oTree 
 Sessions
+{% endblock %}
+
+{% block content %}
+{{ block.super }}
+
 <div class="btn-group" style="float: right;">
     <a class="btn btn-primary" href="{% url 'CreateSession' %}">
         <span class="glyphicon glyphicon-plus"></span> Create new session
@@ -118,9 +124,8 @@ Sessions
         <li><a href="{% url 'CreateSession' %}?mturk=1">For MTurk</a></li>
     </ul>
 </div>
-{% endblock %}
-{% block content %}
-{{ block.super }}
+
+
 <div class="modal fade" id="delete-confirm" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content panel-danger">


### PR DESCRIPTION
…long; max key length is 767 bytes" (Session._pre_create_id max_length must be <= 255 for MySQL when it's specified as index)

The issue arises when you're running "otree resetdb" with MySQL (5.5 in my case). It will show two MySQL related warnings. It's probably the [same issue as described here](http://stackoverflow.com/questions/1814532/1071-specified-key-was-too-long-max-key-length-is-767-bytes).

I set `Session._pre_create_id`'s `max_length` to 255 which fixes the problem. Since the generated IDs are 32 characters long (from what I've seen -- please confirm that), this shouldn't cause any other problems.