### PR TITLE
Fix comparison of string literal

### DIFF
--- a/otree/views/abstract.py
+++ b/otree/views/abstract.py
@@ -965,7 +965,7 @@ class Page(FormPageOrInGameWaitPage):
 
     def remaining_timeout_seconds(self):
 
-        if self._remaining_timeout_seconds is not 'unset':
+        if self._remaining_timeout_seconds != 'unset':
             return self._remaining_timeout_seconds
 
         try:


### PR DESCRIPTION
!= instead of is not
See https://discuss.python.org/t/demoting-the-is-operator-to-avoid-an-identity-crisis/86