### PR TITLE
Allowing for repeated roles with the new role format

### DIFF
--- a/otree/constants.py
+++ b/otree/constants.py
@@ -59,6 +59,8 @@ def get_roles(Constants) -> list:
                 msg = f"{k}: any Constant that starts with 'role_' must be a string, for example: role_sender = 'Sender'"
                 raise Exception(msg)
             roles.append(v)
+    # repeats roles list until there are at least as many roles as players per group
+    roles *= ((Constants.players_per_group - 1) // len(roles)) + 1
     return roles
 
 

--- a/otree/models/group.py
+++ b/otree/models/group.py
@@ -46,12 +46,15 @@ class BaseGroup(models.OTreeModel, GroupIDMapMixin):
             raise ValueError(msg) from None
 
     def get_player_by_role(self, role):
+        """
+        Return a list of all players with that role.
+        """
         if get_roles(self._Constants):
-            try:
+            try:  # if a role is defined (in Constants)
                 return self.player_set.filter(_role=role)
             except django.core.exceptions.ObjectDoesNotExist:
                 pass
-        else:
+        else:  # if a role is defined in the old way, i.e., with player.role()
             players_with_role = [p for p in self.get_players() if p.role() == role]
             return players_with_role
         msg = f'No player with role "{role}"'

--- a/otree/models/group.py
+++ b/otree/models/group.py
@@ -48,13 +48,12 @@ class BaseGroup(models.OTreeModel, GroupIDMapMixin):
     def get_player_by_role(self, role):
         if get_roles(self._Constants):
             try:
-                return self.player_set.get(_role=role)
+                return self.player_set.filter(_role=role)
             except django.core.exceptions.ObjectDoesNotExist:
                 pass
         else:
-            for p in self.get_players():
-                if p.role() == role:
-                    return p
+            players_with_role = [p for p in self.get_players() if p.role() == role]
+            return players_with_role
         msg = f'No player with role "{role}"'
         raise ValueError(msg)
 


### PR DESCRIPTION
So far, it is impossible to have the same role more than once in a group. However, this is required for a lot of experiments (especially the one I am working on right now).

As a suggestion, I have implemented it as follows:
- If there are more players per group than roles, the list of roles is just repeated until there are enough roles for every player
- Unfortunately, I needed to change get_player_by_role to return a list instead of a single player.
- Now, it is less similar to get_player_by_id but the output is similar to get_players.
- For consistency reasons, I have also changed the output of the old way to give a list of all players instead of just the first one.

What I have not changed:
- I guess get_player_by_role should now be called get_players_by_role instead.