### PR TITLE
Avoid trailing space when 'otree zip' edits requirements.txt

### DIFF
--- a/otree/cli/zip.py
+++ b/otree/cli/zip.py
@@ -171,7 +171,7 @@ REQS_BASE_DEFAULT = '''\
 # if someone needs that exact version, they can manage the file manually.
 _REQS_DEFAULT_FMT = f'''\
 # {OVERWRITE_TOKEN}
-# IF YOU MODIFY THIS FILE, remove these comments. 
+# IF YOU MODIFY THIS FILE, remove these comments.
 # otherwise, oTree will automatically overwrite it.
 otree%s>={otree_version}
 psycopg2>=2.8.4


### PR DESCRIPTION
Noticed while trying ``otree zip`` and finding it modified files under git version control.